### PR TITLE
feat: Option and Result should not be used as pointers

### DIFF
--- a/safetypes/option.go
+++ b/safetypes/option.go
@@ -97,12 +97,12 @@ type Option[T any] struct {
 }
 
 // IsNone returns true if the Option is a None value.
-func (o Option[T]) IsNone() bool {
+func (o *Option[T]) IsNone() bool {
 	return !o.ok
 }
 
 // IsNoneOr returns true if the Option is a None or the value inside of it matches a predicate.
-func (o Option[T]) IsNoneOr(f func(T) bool) bool {
+func (o *Option[T]) IsNoneOr(f func(T) bool) bool {
 	if !o.ok {
 		return true
 	}
@@ -111,12 +111,12 @@ func (o Option[T]) IsNoneOr(f func(T) bool) bool {
 }
 
 // IsSome returns true if the Option is a Some value.
-func (o Option[T]) IsSome() bool {
+func (o *Option[T]) IsSome() bool {
 	return o.ok
 }
 
 // IsSomeAnd returns true if the Option is a Some and the value inside of it matches a predicate.
-func (o Option[T]) IsSomeAnd(f func(T) bool) bool {
+func (o *Option[T]) IsSomeAnd(f func(T) bool) bool {
 	if !o.ok {
 		return false
 	}
@@ -125,7 +125,7 @@ func (o Option[T]) IsSomeAnd(f func(T) bool) bool {
 }
 
 // Expect returns the contained Some value. Panics if the value is a None with a custom panic message provided by msg.
-func (o Option[T]) Expect(msg string) T {
+func (o *Option[T]) Expect(msg string) T {
 	if o.ok {
 		return o.val
 	}
@@ -134,7 +134,7 @@ func (o Option[T]) Expect(msg string) T {
 }
 
 // Unwrap returns the contained Some value. Panics if the value equals None.
-func (o Option[T]) Unwrap() T {
+func (o *Option[T]) Unwrap() T {
 	if o.ok {
 		return o.val
 	}
@@ -143,7 +143,7 @@ func (o Option[T]) Unwrap() T {
 }
 
 // UnwrapOr returns the contained Some value or a provided default.
-func (o Option[T]) UnwrapOr(def T) T {
+func (o *Option[T]) UnwrapOr(def T) T {
 	if o.ok {
 		return o.val
 	}
@@ -152,7 +152,7 @@ func (o Option[T]) UnwrapOr(def T) T {
 }
 
 // UnwrapOrElse returns the contained Some value or computes it from a closure.
-func (o Option[T]) UnwrapOrElse(f func() T) T {
+func (o *Option[T]) UnwrapOrElse(f func() T) T {
 	if o.ok {
 		return o.val
 	}
@@ -161,7 +161,7 @@ func (o Option[T]) UnwrapOrElse(f func() T) T {
 }
 
 // UnwrapOrDefault returns the contained Some value or a default.
-func (o Option[T]) UnwrapOrDefault() T {
+func (o *Option[T]) UnwrapOrDefault() T {
 	if o.ok {
 		return o.val
 	}
@@ -172,7 +172,7 @@ func (o Option[T]) UnwrapOrDefault() T {
 }
 
 // AsOkOr converts an Option to an Ok when opt is Some or Err when opt is None.
-func (o Option[T]) AsOkOr(err error) *Result[T] {
+func (o *Option[T]) AsOkOr(err error) Result[T] {
 	if o.ok {
 		return Ok[T](o.val)
 	}
@@ -181,7 +181,7 @@ func (o Option[T]) AsOkOr(err error) *Result[T] {
 }
 
 // AsOkOrElse converts an Option to an Ok when opt is Some or Err when opt is None.
-func (o Option[T]) AsOkOrElse(f func() error) *Result[T] {
+func (o *Option[T]) AsOkOrElse(f func() error) Result[T] {
 	if o.ok {
 		return Ok[T](o.val)
 	}
@@ -190,51 +190,51 @@ func (o Option[T]) AsOkOrElse(f func() error) *Result[T] {
 }
 
 // Inspect calls a function with a reference to the contained value if Some. Returns the original Option.
-func (o Option[T]) Inspect(f func(T)) Option[T] {
+func (o *Option[T]) Inspect(f func(T)) Option[T] {
 	if o.ok {
 		f(o.val)
 	}
 
-	return o
+	return *o
 }
 
 // Filter returns None if the Option is None, otherwise calls predicate with the wrapped value and returns:
 //   - Some(t) if the predicate returns true (where t is the wrapped value), and
 //   - None if the predicate returns false.
-func (o Option[T]) Filter(f func(T) bool) Option[T] {
+func (o *Option[T]) Filter(f func(T) bool) Option[T] {
 	if o.ok && f(o.val) {
-		return o
+		return *o
 	}
 
 	return None[T]()
 }
 
 // Or returns the Option if it contains a value, otherwise returns optb.
-func (o Option[T]) Or(other Option[T]) Option[T] {
+func (o *Option[T]) Or(other Option[T]) Option[T] {
 	if o.ok {
-		return o
+		return *o
 	}
 
 	return other
 }
 
 // OrElse returns the option if it contains a value, otherwise calls f and returns the result.
-func (o Option[T]) OrElse(f func() Option[T]) Option[T] {
+func (o *Option[T]) OrElse(f func() Option[T]) Option[T] {
 	if o.ok {
-		return o
+		return *o
 	}
 
 	return f()
 }
 
 // Xor returns Some if exactly one of self, optb is Some, otherwise returns None.
-func (o Option[T]) Xor(other Option[T]) Option[T] {
+func (o *Option[T]) Xor(other Option[T]) Option[T] {
 	if o.ok == other.ok {
 		return None[T]()
 	}
 
 	if o.ok {
-		return o
+		return *o
 	}
 
 	return other
@@ -322,7 +322,7 @@ func (o *Option[T]) TakeIf(f func(T) bool) Option[T] {
 	return None[T]()
 }
 
-func (o Option[T]) String() string {
+func (o *Option[T]) String() string {
 	if o.ok {
 		return fmt.Sprintf("Some(%v)", o.val)
 	}

--- a/safetypes/option.go
+++ b/safetypes/option.go
@@ -7,25 +7,25 @@ import (
 )
 
 // None creates a None variant of Option.
-func None[T any]() *Option[T] {
+func None[T any]() Option[T] {
 	var v T
 
-	return &Option[T]{
+	return Option[T]{
 		ok:  false,
 		val: v,
 	}
 }
 
 // Some creates a Some variant of Option from the value.
-func Some[T any](val T) *Option[T] {
-	return &Option[T]{
+func Some[T any](val T) Option[T] {
+	return Option[T]{
 		ok:  true,
 		val: val,
 	}
 }
 
 // OptionOf creates an Option from the given value.
-func OptionOf[T any](val T) *Option[T] {
+func OptionOf[T any](val T) Option[T] {
 	if reflect.ValueOf(&val).Elem().IsZero() {
 		return None[T]()
 	}
@@ -37,7 +37,7 @@ func OptionOf[T any](val T) *Option[T] {
 // (if None).
 //
 // With Go 1.27+, use Option[T].Map().
-func MapOption[T any, U any](opt *Option[T], f func(T) U) *Option[U] {
+func MapOption[T any, U any](opt Option[T], f func(T) U) Option[U] {
 	if !opt.ok {
 		return None[U]()
 	}
@@ -48,7 +48,7 @@ func MapOption[T any, U any](opt *Option[T], f func(T) U) *Option[U] {
 // MapOptionOr returns the provided default result (if None), or applies a function to the contained value (if Some).
 //
 // With Go 1.27+, use Option[T].MapOr().
-func MapOptionOr[T any, U any](opt *Option[T], def U, f func(T) U) U {
+func MapOptionOr[T any, U any](opt Option[T], def U, f func(T) U) U {
 	if !opt.ok {
 		return def
 	}
@@ -60,7 +60,7 @@ func MapOptionOr[T any, U any](opt *Option[T], def U, f func(T) U) U {
 // (if Some).
 //
 // With Go 1.27+, use Option[T].MapOrElse().
-func MapOptionOrElse[T any, U any](opt *Option[T], factory func() U, f func(T) U) U {
+func MapOptionOrElse[T any, U any](opt Option[T], factory func() U, f func(T) U) U {
 	if !opt.ok {
 		return factory()
 	}
@@ -71,7 +71,7 @@ func MapOptionOrElse[T any, U any](opt *Option[T], factory func() U, f func(T) U
 // And returns None if the Option is None, otherwise returns `optb`.
 //
 // With Go 1.27+, use Option[T].And().
-func And[T any, U any](opt *Option[T], other *Option[U]) *Option[U] {
+func And[T any, U any](opt Option[T], other Option[U]) Option[U] {
 	if !opt.ok {
 		return None[U]()
 	}
@@ -82,7 +82,7 @@ func And[T any, U any](opt *Option[T], other *Option[U]) *Option[U] {
 // AndThen returns None if the Option is None, otherwise calls `f` with the wrapped value and returns the result.
 //
 // With Go 1.27+, use Option[T].AndThen().
-func AndThen[T any, U any](opt *Option[T], f func(T) *Option[U]) *Option[U] {
+func AndThen[T any, U any](opt Option[T], f func(T) Option[U]) Option[U] {
 	if !opt.ok {
 		return None[U]()
 	}
@@ -97,12 +97,12 @@ type Option[T any] struct {
 }
 
 // IsNone returns true if the Option is a None value.
-func (o *Option[T]) IsNone() bool {
+func (o Option[T]) IsNone() bool {
 	return !o.ok
 }
 
 // IsNoneOr returns true if the Option is a None or the value inside of it matches a predicate.
-func (o *Option[T]) IsNoneOr(f func(T) bool) bool {
+func (o Option[T]) IsNoneOr(f func(T) bool) bool {
 	if !o.ok {
 		return true
 	}
@@ -111,12 +111,12 @@ func (o *Option[T]) IsNoneOr(f func(T) bool) bool {
 }
 
 // IsSome returns true if the Option is a Some value.
-func (o *Option[T]) IsSome() bool {
+func (o Option[T]) IsSome() bool {
 	return o.ok
 }
 
 // IsSomeAnd returns true if the Option is a Some and the value inside of it matches a predicate.
-func (o *Option[T]) IsSomeAnd(f func(T) bool) bool {
+func (o Option[T]) IsSomeAnd(f func(T) bool) bool {
 	if !o.ok {
 		return false
 	}
@@ -125,7 +125,7 @@ func (o *Option[T]) IsSomeAnd(f func(T) bool) bool {
 }
 
 // Expect returns the contained Some value. Panics if the value is a None with a custom panic message provided by msg.
-func (o *Option[T]) Expect(msg string) T {
+func (o Option[T]) Expect(msg string) T {
 	if o.ok {
 		return o.val
 	}
@@ -134,7 +134,7 @@ func (o *Option[T]) Expect(msg string) T {
 }
 
 // Unwrap returns the contained Some value. Panics if the value equals None.
-func (o *Option[T]) Unwrap() T {
+func (o Option[T]) Unwrap() T {
 	if o.ok {
 		return o.val
 	}
@@ -143,7 +143,7 @@ func (o *Option[T]) Unwrap() T {
 }
 
 // UnwrapOr returns the contained Some value or a provided default.
-func (o *Option[T]) UnwrapOr(def T) T {
+func (o Option[T]) UnwrapOr(def T) T {
 	if o.ok {
 		return o.val
 	}
@@ -152,7 +152,7 @@ func (o *Option[T]) UnwrapOr(def T) T {
 }
 
 // UnwrapOrElse returns the contained Some value or computes it from a closure.
-func (o *Option[T]) UnwrapOrElse(f func() T) T {
+func (o Option[T]) UnwrapOrElse(f func() T) T {
 	if o.ok {
 		return o.val
 	}
@@ -161,7 +161,7 @@ func (o *Option[T]) UnwrapOrElse(f func() T) T {
 }
 
 // UnwrapOrDefault returns the contained Some value or a default.
-func (o *Option[T]) UnwrapOrDefault() T {
+func (o Option[T]) UnwrapOrDefault() T {
 	if o.ok {
 		return o.val
 	}
@@ -172,7 +172,7 @@ func (o *Option[T]) UnwrapOrDefault() T {
 }
 
 // AsOkOr converts an Option to an Ok when opt is Some or Err when opt is None.
-func (o *Option[T]) AsOkOr(err error) *Result[T] {
+func (o Option[T]) AsOkOr(err error) *Result[T] {
 	if o.ok {
 		return Ok[T](o.val)
 	}
@@ -181,7 +181,7 @@ func (o *Option[T]) AsOkOr(err error) *Result[T] {
 }
 
 // AsOkOrElse converts an Option to an Ok when opt is Some or Err when opt is None.
-func (o *Option[T]) AsOkOrElse(f func() error) *Result[T] {
+func (o Option[T]) AsOkOrElse(f func() error) *Result[T] {
 	if o.ok {
 		return Ok[T](o.val)
 	}
@@ -190,7 +190,7 @@ func (o *Option[T]) AsOkOrElse(f func() error) *Result[T] {
 }
 
 // Inspect calls a function with a reference to the contained value if Some. Returns the original Option.
-func (o *Option[T]) Inspect(f func(T)) *Option[T] {
+func (o Option[T]) Inspect(f func(T)) Option[T] {
 	if o.ok {
 		f(o.val)
 	}
@@ -201,7 +201,7 @@ func (o *Option[T]) Inspect(f func(T)) *Option[T] {
 // Filter returns None if the Option is None, otherwise calls predicate with the wrapped value and returns:
 //   - Some(t) if the predicate returns true (where t is the wrapped value), and
 //   - None if the predicate returns false.
-func (o *Option[T]) Filter(f func(T) bool) *Option[T] {
+func (o Option[T]) Filter(f func(T) bool) Option[T] {
 	if o.ok && f(o.val) {
 		return o
 	}
@@ -210,7 +210,7 @@ func (o *Option[T]) Filter(f func(T) bool) *Option[T] {
 }
 
 // Or returns the Option if it contains a value, otherwise returns optb.
-func (o *Option[T]) Or(other *Option[T]) *Option[T] {
+func (o Option[T]) Or(other Option[T]) Option[T] {
 	if o.ok {
 		return o
 	}
@@ -219,7 +219,7 @@ func (o *Option[T]) Or(other *Option[T]) *Option[T] {
 }
 
 // OrElse returns the option if it contains a value, otherwise calls f and returns the result.
-func (o *Option[T]) OrElse(f func() *Option[T]) *Option[T] {
+func (o Option[T]) OrElse(f func() Option[T]) Option[T] {
 	if o.ok {
 		return o
 	}
@@ -228,7 +228,7 @@ func (o *Option[T]) OrElse(f func() *Option[T]) *Option[T] {
 }
 
 // Xor returns Some if exactly one of self, optb is Some, otherwise returns None.
-func (o *Option[T]) Xor(other *Option[T]) *Option[T] {
+func (o Option[T]) Xor(other Option[T]) Option[T] {
 	if o.ok == other.ok {
 		return None[T]()
 	}
@@ -295,16 +295,14 @@ func (o *Option[T]) GetOrInsertWith(f func() T) *T {
 }
 
 // Take takes the value out of the Option, leaving a None in its place.
-func (o *Option[T]) Take() *Option[T] {
+func (o *Option[T]) Take() Option[T] {
+	res := *o
+
 	if o.ok {
-		res := *o
-
 		o.ok = false
-
-		return &res
 	}
 
-	return o
+	return res
 }
 
 // TakeIf takes the value out of the Option, but only if the predicate evaluates to true on a mutable reference to
@@ -312,19 +310,19 @@ func (o *Option[T]) Take() *Option[T] {
 //
 // In other words, replaces self with None if the predicate returns true. This method operates similar to take but
 // conditional.
-func (o *Option[T]) TakeIf(f func(T) bool) *Option[T] {
+func (o *Option[T]) TakeIf(f func(T) bool) Option[T] {
 	if o.ok && f(o.val) {
 		res := *o
 
 		o.ok = false
 
-		return &res
+		return res
 	}
 
 	return None[T]()
 }
 
-func (o *Option[T]) String() string {
+func (o Option[T]) String() string {
 	if o.ok {
 		return fmt.Sprintf("Some(%v)", o.val)
 	}

--- a/safetypes/option1.27.go
+++ b/safetypes/option1.27.go
@@ -4,7 +4,7 @@ package st
 
 // Map maps an Option<T> to Option<U> by applying a function to a contained value (if Some) or returns None
 // (if None).
-func (o *Option[T]) Map[U any](f func(T) U) *Option[U] {
+func (o Option[T]) Map[U any](f func(T) U) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}
@@ -13,7 +13,7 @@ func (o *Option[T]) Map[U any](f func(T) U) *Option[U] {
 }
 
 // MapOr returns the provided default result (if None), or applies a function to the contained value (if Some).
-func (o *Option[T]) MapOr[U any](def U, f func(T) U) U {
+func (o Option[T]) MapOr[U any](def U, f func(T) U) U {
 	if !o.ok {
 		return def
 	}
@@ -23,7 +23,7 @@ func (o *Option[T]) MapOr[U any](def U, f func(T) U) U {
 
 // MapOrElse computes a default function result (if None), or applies a different function to the contained value
 // (if Some).
-func (o *Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
+func (o Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
 	if !o.ok {
 		return factory()
 	}
@@ -32,7 +32,7 @@ func (o *Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
 }
 
 // And returns None if the option is None, otherwise returns `optb`.
-func (o *Option[T]) And[U any](other *Option[U]) *Option[U] {
+func (o Option[T]) And[U any](other Option[U]) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}
@@ -41,7 +41,7 @@ func (o *Option[T]) And[U any](other *Option[U]) *Option[U] {
 }
 
 // AndThen returns None if the option is None, otherwise calls `f` with the wrapped value and returns the result.
-func (o *Option[T]) AndThen[U any](f func(T) *Option[U]) *Option[U] {
+func (o Option[T]) AndThen[U any](f func(T) Option[U]) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}

--- a/safetypes/option1.27.go
+++ b/safetypes/option1.27.go
@@ -4,7 +4,7 @@ package st
 
 // Map maps an Option<T> to Option<U> by applying a function to a contained value (if Some) or returns None
 // (if None).
-func (o Option[T]) Map[U any](f func(T) U) Option[U] {
+func (o *Option[T]) Map[U any](f func(T) U) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}
@@ -13,7 +13,7 @@ func (o Option[T]) Map[U any](f func(T) U) Option[U] {
 }
 
 // MapOr returns the provided default result (if None), or applies a function to the contained value (if Some).
-func (o Option[T]) MapOr[U any](def U, f func(T) U) U {
+func (o *Option[T]) MapOr[U any](def U, f func(T) U) U {
 	if !o.ok {
 		return def
 	}
@@ -23,7 +23,7 @@ func (o Option[T]) MapOr[U any](def U, f func(T) U) U {
 
 // MapOrElse computes a default function result (if None), or applies a different function to the contained value
 // (if Some).
-func (o Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
+func (o *Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
 	if !o.ok {
 		return factory()
 	}
@@ -32,7 +32,7 @@ func (o Option[T]) MapOrElse[U any](factory func() U, f func(T) U) U {
 }
 
 // And returns None if the option is None, otherwise returns `optb`.
-func (o Option[T]) And[U any](other Option[U]) Option[U] {
+func (o *Option[T]) And[U any](other Option[U]) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}
@@ -40,8 +40,8 @@ func (o Option[T]) And[U any](other Option[U]) Option[U] {
 	return other
 }
 
-// AndThen returns None if the option is None, otherwise calls `f` with the wrapped value and returns the result.
-func (o Option[T]) AndThen[U any](f func(T) Option[U]) Option[U] {
+// AndThen returns None if the option is None, otherwise calls `f` with the wrapped value, and returns the result.
+func (o *Option[T]) AndThen[U any](f func(T) Option[U]) Option[U] {
 	if !o.ok {
 		return None[U]()
 	}

--- a/safetypes/option1.27_test.go
+++ b/safetypes/option1.27_test.go
@@ -121,7 +121,7 @@ func TestOption_AndThen(t *testing.T) {
 		value := fake.RandomStringWithLength(8)
 		other := Some(value)
 
-		res := o.AndThen(func(int) *Option[string] { return other })
+		res := o.AndThen(func(int) Option[string] { return other })
 
 		assert.Equal(t, other, res)
 	})
@@ -129,7 +129,7 @@ func TestOption_AndThen(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 		o := None[int]()
 
-		f := func(int) *Option[string] {
+		f := func(int) Option[string] {
 			assert.Fail(t, "mapper should not have been called")
 
 			return Some("")

--- a/safetypes/option_marshal.go
+++ b/safetypes/option_marshal.go
@@ -3,8 +3,8 @@ package st
 import "encoding/json"
 
 // MarshalJSON implements json.Marshaler.
-func (o *Option[T]) MarshalJSON() ([]byte, error) {
-	if o == nil || !o.ok {
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	if !o.ok {
 		return []byte("null"), nil
 	}
 

--- a/safetypes/option_marshal_test.go
+++ b/safetypes/option_marshal_test.go
@@ -47,7 +47,7 @@ func TestMarshalJSON(t *testing.T) {
 			struct {
 				Name string
 				Job  *Option[string]
-			}{"Poor Schmuck", None[string]()},
+			}{"Poor Schmuck", ptr(None[string]())},
 			`{"Name": "Poor Schmuck", "Job": null}`,
 		},
 		{
@@ -55,7 +55,7 @@ func TestMarshalJSON(t *testing.T) {
 			struct {
 				Name string
 				Job  *Option[string]
-			}{"Mega Chad", Some("Big Boss")},
+			}{"Mega Chad", ptr(Some("Big Boss"))},
 			`{"Name": "Mega Chad", "Job": "Big Boss"}`,
 		},
 	}
@@ -125,7 +125,7 @@ func TestUnmarshalText(t *testing.T) {
 		err := json.Unmarshal([]byte(`{"Name": "Poor Schmuck", "Job": null}`), &o)
 		require.NoError(t, err)
 
-		expected := Option[S]{ok: true, val: S{"Poor Schmuck", *None[string]()}}
+		expected := Option[S]{ok: true, val: S{"Poor Schmuck", None[string]()}}
 		assert.Equal(t, expected, o)
 	})
 
@@ -139,7 +139,7 @@ func TestUnmarshalText(t *testing.T) {
 		err := json.Unmarshal([]byte(`{"Name": "Mega Chad", "Job": "Big Boss"}`), &o)
 		require.NoError(t, err)
 
-		expected := Option[S]{ok: true, val: S{"Mega Chad", *Some("Big Boss")}}
+		expected := Option[S]{ok: true, val: S{"Mega Chad", Some("Big Boss")}}
 		assert.Equal(t, expected, o)
 	})
 

--- a/safetypes/option_test.go
+++ b/safetypes/option_test.go
@@ -889,7 +889,3 @@ func TestOption_String(t *testing.T) {
 		assert.Equal(t, expected, o.String())
 	})
 }
-
-func ptr[T any](v T) *T {
-	return &v
-}

--- a/safetypes/option_test.go
+++ b/safetypes/option_test.go
@@ -171,7 +171,7 @@ func TestAndThen_ReturnsMappedOptionOrNone(t *testing.T) {
 		s := Some(val)
 
 		other := Some(fake.RandomStringWithLength(8))
-		f := func(o int) *Option[string] {
+		f := func(o int) Option[string] {
 			assert.Equal(t, val, o)
 
 			return other
@@ -183,7 +183,7 @@ func TestAndThen_ReturnsMappedOptionOrNone(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 		n := None[int]()
 
-		f := func(int) *Option[string] {
+		f := func(int) Option[string] {
 			assert.Fail(t, "mapper should not have been called")
 
 			return None[string]()
@@ -467,7 +467,7 @@ func TestOption_Inspect(t *testing.T) {
 			assert.Equal(t, val, v)
 		}
 
-		assert.Same(t, o, o.Inspect(predicate))
+		assert.Equal(t, o, o.Inspect(predicate))
 		assert.True(t, called)
 	})
 
@@ -478,7 +478,7 @@ func TestOption_Inspect(t *testing.T) {
 			assert.Fail(t, "predicate should not be called")
 		}
 
-		assert.Same(t, o, o.Inspect(predicate))
+		assert.Equal(t, o, o.Inspect(predicate))
 	})
 }
 
@@ -552,7 +552,7 @@ func TestOption_OrElse(t *testing.T) {
 		val := fake.Int()
 		o := Some(val)
 
-		otherFactory := func() *Option[int] {
+		otherFactory := func() Option[int] {
 			assert.Fail(t, "factory should not be called")
 
 			return Some(fake.Int())
@@ -565,7 +565,7 @@ func TestOption_OrElse(t *testing.T) {
 		o := None[int]()
 
 		other := Some(fake.Int())
-		otherFactory := func() *Option[int] {
+		otherFactory := func() Option[int] {
 			return other
 		}
 
@@ -585,7 +585,7 @@ func TestOption_Xor(t *testing.T) {
 
 		t.Run("other is none", func(t *testing.T) {
 			other := None[int]()
-			assert.Same(t, o, o.Xor(other))
+			assert.Equal(t, o, o.Xor(other))
 		})
 	})
 
@@ -594,7 +594,7 @@ func TestOption_Xor(t *testing.T) {
 
 		t.Run("other is some", func(t *testing.T) {
 			other := Some(fake.Int())
-			assert.Same(t, other, o.Xor(other))
+			assert.Equal(t, other, o.Xor(other))
 		})
 
 		t.Run("other is none", func(t *testing.T) {
@@ -614,7 +614,7 @@ func TestOption_Insert(t *testing.T) {
 
 		assert.Equal(t, newVal, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: newVal,
 		}
@@ -634,7 +634,7 @@ func TestOption_Insert(t *testing.T) {
 
 		assert.Equal(t, newVal, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: newVal,
 		}
@@ -657,7 +657,7 @@ func TestOption_GetOrInsert(t *testing.T) {
 
 		assert.Equal(t, val, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: val,
 		}
@@ -677,7 +677,7 @@ func TestOption_GetOrInsert(t *testing.T) {
 
 		assert.Equal(t, newVal, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: newVal,
 		}
@@ -699,7 +699,7 @@ func TestOption_GetOrInsertDefault(t *testing.T) {
 
 		assert.Equal(t, val, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: val,
 		}
@@ -718,7 +718,7 @@ func TestOption_GetOrInsertDefault(t *testing.T) {
 
 		assert.Equal(t, 0, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: 0,
 		}
@@ -746,7 +746,7 @@ func TestOption_GetOrInsertWith(t *testing.T) {
 
 		assert.Equal(t, val, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: val,
 		}
@@ -769,7 +769,7 @@ func TestOption_GetOrInsertWith(t *testing.T) {
 
 		assert.Equal(t, newVal, *res)
 
-		expected := &Option[int]{
+		expected := Option[int]{
 			ok:  true,
 			val: newVal,
 		}
@@ -888,4 +888,8 @@ func TestOption_String(t *testing.T) {
 
 		assert.Equal(t, expected, o.String())
 	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/safetypes/option_validation_test.go
+++ b/safetypes/option_validation_test.go
@@ -21,37 +21,37 @@ func TestValidations(t *testing.T) {
 	}{
 		{
 			"valid string",
-			*Some[any]("valid"),
+			Some[any]("valid"),
 			"",
 		},
 		{
 			"valid empty string",
-			*Some[any](""),
+			Some[any](""),
 			"",
 		},
 		{
 			"invalid string",
-			*Some[any]("too long"),
+			Some[any]("too long"),
 			"max",
 		},
 		{
 			"valid int value",
-			*Some[any](3),
+			Some[any](3),
 			"",
 		},
 		{
 			"valid zero int",
-			*Some[any](0),
+			Some[any](0),
 			"",
 		},
 		{
 			"invalid int",
-			*Some[any](6),
+			Some[any](6),
 			"max",
 		},
 		{
 			"none",
-			*None[any](),
+			None[any](),
 			"required",
 		},
 	}

--- a/safetypes/result.go
+++ b/safetypes/result.go
@@ -210,7 +210,7 @@ func (r *Result[T]) InspectErr(f func(error)) *Result[T] {
 }
 
 // AsOptionValue converts a Result to a Some when res is a result.Ok or None when res is a result.Err.
-func (r *Result[T]) AsOptionValue() *Option[T] {
+func (r *Result[T]) AsOptionValue() Option[T] {
 	if r.ok {
 		return Some(r.val)
 	}
@@ -219,7 +219,7 @@ func (r *Result[T]) AsOptionValue() *Option[T] {
 }
 
 // AsOptionErr converts a Result to a Some when res is a result.Err or None when res is a result.Ok.
-func (r *Result[T]) AsOptionErr() *Option[error] {
+func (r *Result[T]) AsOptionErr() Option[error] {
 	if !r.ok {
 		return Some(r.err)
 	}

--- a/safetypes/result.go
+++ b/safetypes/result.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Ok creates an Ok variant of Result from the value.
-func Ok[T any](val T) *Result[T] {
-	return &Result[T]{
+func Ok[T any](val T) Result[T] {
+	return Result[T]{
 		ok:  true,
 		val: val,
 		err: nil,
@@ -15,10 +15,10 @@ func Ok[T any](val T) *Result[T] {
 }
 
 // Err creates an Err variant of Result from the error.
-func Err[T any](err error) *Result[T] {
+func Err[T any](err error) Result[T] {
 	var v T
 
-	return &Result[T]{
+	return Result[T]{
 		ok:  false,
 		val: v,
 		err: err,
@@ -26,7 +26,7 @@ func Err[T any](err error) *Result[T] {
 }
 
 // ResultOf creates a Result from the given value and error.
-func ResultOf[T any](val T, err error) *Result[T] {
+func ResultOf[T any](val T, err error) Result[T] {
 	if !reflect.ValueOf(&err).Elem().IsNil() {
 		return Err[T](err)
 	}
@@ -38,7 +38,7 @@ func ResultOf[T any](val T, err error) *Result[T] {
 // untouched.
 //
 // With Go 1.27+, use Result[T].Map().
-func MapResult[T any, U any](res *Result[T], f func(T) U) *Result[U] {
+func MapResult[T any, U any](res Result[T], f func(T) U) Result[U] {
 	if res.IsErr() {
 		return Err[U](res.err)
 	}
@@ -49,7 +49,7 @@ func MapResult[T any, U any](res *Result[T], f func(T) U) *Result[U] {
 // MapResultOr returns the provided default (if Err), or applies a function to the contained value (if Ok).
 //
 // With Go 1.27+, use Result[T].MapOr().
-func MapResultOr[T any, U any](res *Result[T], def U, f func(T) U) U {
+func MapResultOr[T any, U any](res Result[T], def U, f func(T) U) U {
 	if res.IsErr() {
 		return def
 	}
@@ -62,7 +62,7 @@ func MapResultOr[T any, U any](res *Result[T], def U, f func(T) U) U {
 //
 // With Go 1.27+, use Result[T].MapOrElse().
 func MapResultOrElse[T any, U any](
-	res *Result[T],
+	res Result[T],
 	factory func() U,
 	mapper func(T) U,
 ) U {
@@ -77,7 +77,7 @@ func MapResultOrElse[T any, U any](
 // untouched.
 //
 // With Go 1.27+, use Result[T].MapErr().
-func MapResultErr[T any](res *Result[T], f func(error) error) *Result[T] {
+func MapResultErr[T any](res Result[T], f func(error) error) Result[T] {
 	if res.IsOk() {
 		return res
 	}
@@ -114,9 +114,9 @@ func (r *Result[T]) IsErrAnd(f func(error) bool) bool {
 
 // MapErr maps a Result<T> to Result<T, F> by applying a function to a contained Err value, leaving an Ok value
 // untouched.
-func (r *Result[T]) MapErr(f func(error) error) *Result[T] {
+func (r *Result[T]) MapErr(f func(error) error) Result[T] {
 	if r.ok {
-		return r
+		return *r
 	}
 
 	return Err[T](f(r.err))
@@ -192,21 +192,21 @@ func (r *Result[T]) UnwrapErr() error {
 }
 
 // Inspect calls a function with a reference to the contained value if Ok. Returns the original result.
-func (r *Result[T]) Inspect(f func(*T)) *Result[T] {
+func (r *Result[T]) Inspect(f func(*T)) Result[T] {
 	if r.ok {
 		f(&r.val)
 	}
 
-	return r
+	return *r
 }
 
 // InspectErr calls a function with a reference to the contained value if Err. Returns the original result.
-func (r *Result[T]) InspectErr(f func(error)) *Result[T] {
+func (r *Result[T]) InspectErr(f func(error)) Result[T] {
 	if !r.ok {
 		f(r.err)
 	}
 
-	return r
+	return *r
 }
 
 // AsOptionValue converts a Result to a Some when res is a result.Ok or None when res is a result.Err.
@@ -228,12 +228,12 @@ func (r *Result[T]) AsOptionErr() Option[error] {
 }
 
 // WrapErr wraps the error of an Err, leaving Ok untouched.
-func (r *Result[T]) WrapErr(msg string) *Result[T] {
+func (r *Result[T]) WrapErr(msg string) Result[T] {
 	if !r.ok {
 		return Err[T](fmt.Errorf("%s: %w", msg, r.err))
 	}
 
-	return r
+	return *r
 }
 
 // Expand returns the Result as a standard Go (T, error).

--- a/safetypes/result1.27.go
+++ b/safetypes/result1.27.go
@@ -4,7 +4,7 @@ package st
 
 // Map maps a Result<T> to Result<U, E> by applying a function to a contained Ok value, leaving an Err value
 // untouched.
-func (r *Result[T]) Map[U any](f func(T) U) *Result[U] {
+func (r *Result[T]) Map[U any](f func(T) U) Result[U] {
 	if !r.ok {
 		return Err[U](r.err)
 	}

--- a/safetypes/result_test.go
+++ b/safetypes/result_test.go
@@ -472,7 +472,7 @@ func TestResult_Inspect(t *testing.T) {
 
 		res := r.Inspect(p)
 
-		assert.Same(t, res, r)
+		assert.Equal(t, res, r)
 		assert.True(t, called, "predicate should have been called")
 	})
 
@@ -486,7 +486,7 @@ func TestResult_Inspect(t *testing.T) {
 
 		res := r.Inspect(p)
 
-		assert.Same(t, res, r)
+		assert.Equal(t, res, r)
 	})
 }
 
@@ -501,7 +501,7 @@ func TestResult_InspectErr(t *testing.T) {
 
 		res := r.InspectErr(p)
 
-		assert.Same(t, res, r)
+		assert.Equal(t, res, r)
 	})
 
 	t.Run("Err", func(t *testing.T) {
@@ -517,7 +517,7 @@ func TestResult_InspectErr(t *testing.T) {
 
 		res := r.InspectErr(p)
 
-		assert.Same(t, res, r)
+		assert.Equal(t, res, r)
 		assert.True(t, called, "predicate should have been called")
 	})
 }
@@ -559,7 +559,7 @@ func TestResult_WrapErr(t *testing.T) {
 		val := fake.Int()
 		r := Ok(val)
 
-		assert.Same(t, r, r.WrapErr(fake.RandomStringWithLength(8)))
+		assert.Equal(t, r, r.WrapErr(fake.RandomStringWithLength(8)))
 	})
 
 	t.Run("Err", func(t *testing.T) {

--- a/safetypes/safetypes_test.go
+++ b/safetypes/safetypes_test.go
@@ -5,3 +5,7 @@ import (
 )
 
 var fake = faker.New()
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Having new `Option`s and `Result`s being pointers by default defeats their purpose of _not_ having to check for `nil`s.